### PR TITLE
Consumer metadata improvements

### DIFF
--- a/lib/heller/consumer.rb
+++ b/lib/heller/consumer.rb
@@ -34,6 +34,7 @@ module Heller
       request = Kafka::JavaApi::TopicMetadataRequest.new(topics)
       TopicMetadataResponse.new(@consumer.send(request))
     end
+    alias_method :topic_metadata, :metadata
 
     def offsets_before(offset_requests)
       request_info = Array(offset_requests).each_with_object({}) do |request, memo|

--- a/spec/heller/consumer_spec.rb
+++ b/spec/heller/consumer_spec.rb
@@ -348,6 +348,11 @@ module Heller
           end
         end
       end
+
+      it 'is aliased as #topic_metadata' do
+        consumer.topic_metadata
+        expect(consumer_spy).to have_received(:send).with(an_instance_of(Kafka::JavaApi::TopicMetadataRequest))
+      end
     end
 
     context '#disconnect' do


### PR DESCRIPTION
Since sending a `TopicMetadataRequest` with an empty list of topics is how you list all topics, this removes the explicit short-circuiting in `Consumer#metadata` when the argument is empty.

It also adds an alias as suggested in #2.

I also took the liberty of refactoring the tests for `Consumer#metadata` to to `expect(...).to have_received(...)` instead of `expect(...).to receive(...)`. The former means that the assertions are done at the end of the test, not in the test setup, and makes it easier to understand what is actually being tested.
