### PR TITLE
Depend on a release of kafka-jars

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'kafka-jars', github: 'mthssdrbrg/kafka-jars'
+gemspec
 
 group :test do
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,8 @@
-GIT
-  remote: git://github.com/mthssdrbrg/kafka-jars.git
-  revision: b2f5f223f5ad690c78bfe63b2a0eda3940c0fb13
+PATH
+  remote: .
   specs:
-    kafka-jars (0.8.1.1.pre0-java)
-      metrics-core-jars (~> 2.1.2)
-      scala-library-jars (~> 2.9.2)
-      slf4j-jars (~> 1.7.7)
-      slyphon-log4j (~> 1.2.15)
-      snappy-jars (~> 1.1.0.1)
-      zookeeper-jars (~> 3.4.6)
+    heller (0.1.0-java)
+      kafka-jars (= 0.8.1.1.pre0)
 
 GEM
   remote: https://rubygems.org/
@@ -21,8 +15,10 @@ GEM
       thor
     diff-lcs (1.2.5)
     docile (1.1.3)
-    metrics-core-jars (2.1.2-java)
-      slf4j-jars (~> 1)
+    kafka-jars (0.8.1.1.pre0-java)
+      scala-library-jars (~> 2.9.2)
+      slf4j-jars (~> 1.6.2)
+      zookeeper-jars (~> 3.4.6)
     mime-types (2.3)
     multi_json (1.10.1)
     rest-client (1.6.7)
@@ -45,9 +41,7 @@ GEM
       multi_json
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
-    slf4j-jars (1.7.7-java)
-    slyphon-log4j (1.2.15)
-    snappy-jars (1.1.0.1.2-java)
+    slf4j-jars (1.6.2-java)
     term-ansicolor (1.3.0)
       tins (~> 1.0)
     thor (0.19.1)
@@ -59,6 +53,6 @@ PLATFORMS
 
 DEPENDENCIES
   coveralls
-  kafka-jars!
+  heller!
   rspec
   simplecov

--- a/heller.gemspec
+++ b/heller.gemspec
@@ -19,4 +19,6 @@ Gem::Specification.new do |s|
   s.require_paths = %w(lib)
 
   s.platform    = 'java'
+
+  s.add_runtime_dependency 'kafka-jars', '= 0.8.1.1.pre0'
 end


### PR DESCRIPTION
And add the dependency to the .gemspec so it becomes transitive.

It also takes forever to load kafka-jars from Github since it's massive.
